### PR TITLE
Implement unsubscribe logic - 3

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -350,7 +350,10 @@ export class AuthService {
     }
     const userEmail = { to: [user.email] }
     const mail = new ForgottenPasswordMailDto(profile)
-    await this.sendEmail.sendFromTemplate(mail, userEmail)
+    await this.sendEmail.sendFromTemplate(mail, userEmail, {
+      //Allow users to receive the mail, regardles of unsubscribes
+      bypassUnsubscribeManagement: { enable: true },
+    })
   }
 
   async updateForgottenPassword(recoveryPasswordDto: NewPasswordDto) {

--- a/apps/api/src/email/email.service.spec.ts
+++ b/apps/api/src/email/email.service.spec.ts
@@ -53,12 +53,15 @@ describe('EmailService enabled ', () => {
 
   it('send() should send email successfully', async () => {
     await emailService.send(emailMock)
-    expect(sendMock).toHaveBeenCalledWith(emailMock)
+    expect(sendMock).toHaveBeenCalledWith({
+      ...emailMock,
+      mailSettings: expect.any(Object),
+    })
   })
 
   it('sendFromTemplate() should send email successfully', async () => {
     await emailService.sendFromTemplate({} as EmailTemplate<CreateRequestDto>, partialEmail)
-    expect(sendMock).toHaveBeenCalledWith(emailMock)
+    expect(sendMock).toHaveBeenCalledWith({ ...emailMock, mailSettings: expect.any(Object) })
   })
 
   it('sendFromTemplate() should send email successfully with default sender', async () => {
@@ -66,7 +69,11 @@ describe('EmailService enabled ', () => {
       ...partialEmail,
       ...{ from: undefined },
     })
-    expect(sendMock).toHaveBeenCalledWith({ ...emailMock, ...{ from: 'info@podkrepi.bg' } })
+    expect(sendMock).toHaveBeenCalledWith({
+      ...emailMock,
+      ...{ from: 'info@podkrepi.bg' },
+      mailSettings: expect.any(Object),
+    })
   })
 
   it('sendFromTemplate() should throw error for missing recipient', async () => {

--- a/apps/api/src/notifications/dto/subscribe.dto.ts
+++ b/apps/api/src/notifications/dto/subscribe.dto.ts
@@ -33,9 +33,29 @@ export class SubscribePublicDto {
   public readonly campaignId?: string
 }
 
+export class UnsubscribePublicDto {
+  @ApiProperty()
+  @Expose()
+  @IsNotEmpty()
+  @IsEmail()
+  public readonly email: string
+
+  @ApiProperty()
+  @Expose()
+  @IsOptional()
+  public readonly campaignId?: string
+}
+
 export class SubscribeDto {
   @ApiProperty()
   @Expose()
   @IsBoolean()
   public readonly consent: boolean
+}
+
+export class UnsubscribeDto {
+  @ApiProperty()
+  @Expose()
+  @IsOptional()
+  public readonly campaignId?: string
 }

--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -1,20 +1,21 @@
-import { BadRequestException, Body, Controller, Post } from '@nestjs/common'
+import { BadRequestException, Body, Controller, Get, Post } from '@nestjs/common'
 import { ApiTags } from '@nestjs/swagger'
 import { AuthenticatedUser, Public } from 'nest-keycloak-connect'
-import { SendConfirmationDto, SubscribeDto, SubscribePublicDto } from './dto/subscribe.dto'
-import { PersonService } from '../person/person.service'
-import { ConfigService } from '@nestjs/config'
+import {
+  SendConfirmationDto,
+  SubscribeDto,
+  SubscribePublicDto,
+  UnsubscribeDto,
+  UnsubscribePublicDto,
+} from './dto/subscribe.dto'
+
 import { MarketingNotificationsService } from './notifications.service'
 import { KeycloakTokenParsed } from '../auth/keycloak'
 
 @ApiTags('notifications')
 @Controller('notifications')
 export class MarketingNotificationsController {
-  constructor(
-    private readonly marketingNotificationsService: MarketingNotificationsService,
-    private readonly personService: PersonService,
-    private readonly config: ConfigService,
-  ) {}
+  constructor(private readonly marketingNotificationsService: MarketingNotificationsService) {}
 
   //   Sends confirmation mail to non-registered email address
   @Post('send-confirm-email')
@@ -33,6 +34,13 @@ export class MarketingNotificationsController {
     return await this.marketingNotificationsService.subscribePublic(data)
   }
 
+  // Unsubscribe to receive marketing notifications
+  @Post('/public/unsubscribe')
+  @Public()
+  async unsubscribePublic(@Body() data: UnsubscribePublicDto) {
+    return await this.marketingNotificationsService.unsubscribePublic(data)
+  }
+
   //   Subscribe for logged-in users
   @Post('/subscribe')
   async subscribe(@AuthenticatedUser() user: KeycloakTokenParsed, @Body() data: SubscribeDto) {
@@ -40,5 +48,19 @@ export class MarketingNotificationsController {
       throw new BadRequestException('Notification consent should be provided')
 
     return await this.marketingNotificationsService.subscribe(user)
+  }
+
+  //   Unsubscribe for logged-in users
+  @Post('/unsubscribe')
+  async unsubscribe(@AuthenticatedUser() user: KeycloakTokenParsed, @Body() data: UnsubscribeDto) {
+    return await this.marketingNotificationsService.unsubscribe(data, user)
+  }
+
+  //   Get campaign notifications for logged-in users
+  @Get('/campaign-notifications')
+  async campaignNotifications(@AuthenticatedUser() user: KeycloakTokenParsed) {
+    return await this.marketingNotificationsService.getCampaignNotificationSubscriptions(
+      user.email || '',
+    )
   }
 }

--- a/apps/api/src/notifications/providers/notifications.interface.providers.ts
+++ b/apps/api/src/notifications/providers/notifications.interface.providers.ts
@@ -4,12 +4,30 @@ type NotificationsInterfaceParams = {
   DeleteListParams: any
   AddToListParams: any
   RemoveFromListParams: any
+  GetContactsInfoParams: any
+  RemoveFromUnsubscribedParams: any
+  AddToUnsubscribedParams: any
+
+  // Responses
+  CreateListRes: any
+  UpdateListRes: any
+  DeleteListRes: any
+  AddToListRes: any
+  RemoveFromListRes: any
+  GetContactsInfoRes: any
+  RemoveFromUnsubscribedRes: any
+  AddToUnsubscribedRes: any
 }
 
 export abstract class NotificationsProviderInterface<T extends NotificationsInterfaceParams> {
-  abstract createNewContactList(data: T['CreateListParams']): Promise<string>
-  abstract updateContactList(data: T['UpdateListParams']): Promise<any>
-  abstract deleteContactList(data: T['DeleteListParams']): Promise<any>
-  abstract addContactsToList(data: T['AddToListParams']): Promise<any>
-  abstract removeContactsFromList(data: T['RemoveFromListParams']): Promise<any>
+  abstract createNewContactList(data: T['CreateListParams']): Promise<T['CreateListRes']>
+  abstract updateContactList(data: T['UpdateListParams']): Promise<T['UpdateListRes']>
+  abstract deleteContactList(data: T['DeleteListParams']): Promise<T['DeleteListRes']>
+  abstract addContactsToList(data: T['AddToListParams']): Promise<T['AddToListRes']>
+  abstract getContactsInfo(data: T['GetContactsInfoParams']): Promise<T['GetContactsInfoRes']>
+  abstract addToUnsubscribed(data: T['AddToUnsubscribedParams']): Promise<T['AddToUnsubscribedRes']>
+  abstract removeContactsFromList(data: T['RemoveFromListParams']): Promise<T['RemoveFromListRes']>
+  abstract removeFromUnsubscribed(
+    data: T['RemoveFromUnsubscribedParams'],
+  ): Promise<T['RemoveFromUnsubscribedRes']>
 }

--- a/apps/api/src/notifications/providers/notifications.sendgrid.provider.ts
+++ b/apps/api/src/notifications/providers/notifications.sendgrid.provider.ts
@@ -83,4 +83,43 @@ export class SendGridNotificationsProvider
 
     return response
   }
+
+  async getContactsInfo(data: SendGridParams['GetContactsInfoParams']) {
+    const request = {
+      url: `/v3/marketing/contacts/search/emails`,
+      method: 'POST',
+      body: data,
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    return response.body['result'] as SendGridParams['GetContactsInfoRes']
+  }
+
+  async addToUnsubscribed(data: SendGridParams['AddToUnsubscribedParams']) {
+    const payload = {
+      recipient_emails: data.emails,
+    }
+
+    const request = {
+      url: `/v3/asm/suppressions/global`,
+      method: 'POST',
+      body: payload,
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    return response
+  }
+
+  async removeFromUnsubscribed(data: SendGridParams['RemoveFromUnsubscribedParams']) {
+    const request = {
+      url: `/v3/asm/suppressions/global/${data.email}`,
+      method: 'DELETE',
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    return response
+  }
 }

--- a/apps/api/src/notifications/providers/notifications.sendgrid.types.ts
+++ b/apps/api/src/notifications/providers/notifications.sendgrid.types.ts
@@ -1,9 +1,25 @@
 export type SendGridParams = {
+  // Parameters
   CreateListParams: CreateListParams
   UpdateListParams: UpdateListParams
   DeleteListParams: DeleteListParams
   AddToListParams: AddToListParams
   RemoveFromListParams: RemoveFromListParams
+  GetContactsInfoParams: GetContactsInfoParams
+  RemoveFromUnsubscribedParams: RemoveFromUnsubscribedParams
+  AddToUnsubscribedParams: AddToUnsubscribedParams
+
+  // Responses
+  CreateListRes: string
+  UpdateListRes: any
+  DeleteListRes: any
+  AddToListRes: any
+  RemoveFromListRes: any
+  GetContactsInfoRes: GetContactsInfoRes
+  RemoveFromUnsubscribedRes: any
+  AddToUnsubscribedRes: any
+
+  // Implementation specific
   ContactData: ContactData
 }
 
@@ -35,4 +51,21 @@ type AddToListParams = {
 type RemoveFromListParams = {
   list_id: string
   contact_ids: string[]
+}
+
+type GetContactsInfoParams = {
+  emails: string[]
+}
+
+type RemoveFromUnsubscribedParams = {
+  email: string
+}
+
+type AddToUnsubscribedParams = {
+  emails: string[]
+}
+
+// Reponses
+type GetContactsInfoRes = {
+  [key: string]: { contact: { id: string; [key: string]: any; list_ids: string[] } }
 }

--- a/apps/api/src/support/support.service.ts
+++ b/apps/api/src/support/support.service.ts
@@ -75,22 +75,50 @@ export class SupportService {
 
   async sendWelcomeEmail(inputDto: CreateRequestDto) {
     const email = new WelcomeEmailDto(inputDto)
-    this.emailService.sendFromTemplate(email, { to: [inputDto.person.email] })
+    this.emailService.sendFromTemplate(
+      email,
+      { to: [inputDto.person.email] },
+      {
+        //Allow users to receive the mail, regardles of unsubscribes
+        bypassUnsubscribeManagement: { enable: true },
+      },
+    )
   }
 
   async sendWelcomeInternalEmail(inputDto: CreateRequestDto) {
     const email = new WelcomeInternalEmailDto(inputDto)
-    this.emailService.sendFromTemplate(email, { to: [this.getInternalEmail()] })
+    this.emailService.sendFromTemplate(
+      email,
+      { to: [this.getInternalEmail()] },
+      {
+        //Allow users to receive the mail, regardles of unsubscribes
+        bypassUnsubscribeManagement: { enable: true },
+      },
+    )
   }
 
   async sendInquiryReceivedEmail(inputDto: CreateInquiryDto) {
     const email = new InquiryReceivedEmailDto(inputDto)
-    this.emailService.sendFromTemplate(email, { to: [inputDto.email] })
+    this.emailService.sendFromTemplate(
+      email,
+      { to: [inputDto.email] },
+      {
+        //Allow users to receive the mail, regardles of unsubscribes
+        bypassUnsubscribeManagement: { enable: true },
+      },
+    )
   }
 
   async sendInquiryReceivedInternalEmail(inputDto: CreateInquiryDto) {
     const email = new InquiryReceivedInternalEmailDto(inputDto)
-    this.emailService.sendFromTemplate(email, { to: [this.getInternalEmail()] })
+    this.emailService.sendFromTemplate(
+      email,
+      { to: [this.getInternalEmail()] },
+      {
+        //Allow users to receive the mail, regardles of unsubscribes
+        bypassUnsubscribeManagement: { enable: true },
+      },
+    )
   }
 
   getInternalEmail(): string {

--- a/apps/api/src/tasks/bank-import/import-transactions.task.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.ts
@@ -112,7 +112,10 @@ export class IrisTasks {
       })
 
       // Send Notification
-      await this.sendEmail.sendFromTemplate(mail, recepient)
+      await this.sendEmail.sendFromTemplate(mail, recepient, {
+        //Allow users to receive the mail, regardles of unsubscribes
+        bypassUnsubscribeManagement: { enable: true },
+      })
     }
   }
 
@@ -432,7 +435,10 @@ export class IrisTasks {
     })
 
     // Send Notification
-    await this.sendEmail.sendFromTemplate(mail, recepient)
+    await this.sendEmail.sendFromTemplate(mail, recepient, {
+      //Allow users to receive the mail, regardles of unsubscribes
+      bypassUnsubscribeManagement: { enable: true },
+    })
 
     // Mark notified
     await this.prisma.bankTransaction.updateMany({


### PR DESCRIPTION
FE PR -> https://github.com/BogoCvetkov/podkrepi-frontend/pull/4

New routes have been added to the `NotificationsController`:
1. `/public-unsubscribe` -> this is the unsubscribe link uncluded in all emails. Actually a FE link is included, which internally calls this one. Similarly to the `/public/subscribe` logic if only email is provided -> the email is unsubscribed from ALL notifications, if `email +campaignId` is provided than the email is removed only from the notification list for that campaign
2. `/unsubscribe` -> used by logged users to manage their UNsubscriptions from the dashboard -> again the `email`/`email+campaignId` logic is the same
3. `/campaign-notification` -> Get's info from SendGrid about which campaign lists the user is subscribed to currently
4. Adding an email to the global unsubscribe group prevents them from receiving any emails, so I've added an additional option to all essential emails (forget-password, confirm-email etc), so that they can get trough that filter.